### PR TITLE
Make test 366 pass by adding "move:" to expectation

### DIFF
--- a/test/lib/contents.lua
+++ b/test/lib/contents.lua
@@ -77,7 +77,7 @@ do --- 5.2 string +lua>=5.2
 end
 
 do --- pre-5.2 table +lua<5.2
-  check(table, "concat:foreach:foreachi:getn:insert:maxn:remove:sort", "pack:unpack:setn:new")
+  check(table, "concat:foreach:foreachi:getn:insert:maxn:move:remove:sort", "pack:unpack:setn:new")
 end
 
 do --- 5.2 table +lua>=5.2


### PR DESCRIPTION
I have cherry-picked this change from commit
52015c1f5bc7a9c60f29c2c4109b9be0905eeef3 of @DemiMarie's `fixed-goto`
branch published at LuaJIT/LuaJIT-test-cleanup#13.

I hope it is right! :-)